### PR TITLE
Fix publish CI

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Load project info
         run: |
           git for-each-ref $GITHUB_REF --format '%(contents)' > CHANGELOG.g.md
-          echo GAME_VERSIONS=`jq -c .depends.minecraft src/main/resources/fabric.mod.json` >> $GITHUB_OUTPUT
+          echo GAME_VERSIONS=`jq -c .depends.minecraft src/main/resources/fabric.mod.json` >> $GITHUB_ENV
       - name: Publish to GitHub, Modrinth, and CurseForge
         uses: Kir-Antipov/mc-publish@v3.2
         with:


### PR DESCRIPTION
The project info was loaded to the output instead of the environment. This caused it to be empty. Now the project info gets loaded to the environment, where the next step expects it.