### PR TITLE
OptiGUI 2.0.0-alpha.1 fix

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -31,7 +31,7 @@
     "fabric-api": ">=${fabric_api}",
     "fabric-language-kotlin": ">=${fabric_language_kotlin}",
     "minecraft": [
-      "=1.19.3"
+      "1.19.3"
     ],
     "java": ">=${java}"
   }


### PR DESCRIPTION
Same as #2, but changed the Minecraft version in `fabric.mod.json` to not break the publishing task.