### PR TITLE
OptiGUI 2.0.0-alpha.6

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,11 +42,11 @@ jobs:
           curseforge-id: ${{ vars.CURSEFORGE_ID }}
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
           curseforge-dependencies: |
-            306612 | depends | *
-            308769 | depends | 1.9.0+kotlin.1.8.0
-            629673 | recommends | *
-            533006 | suggests | *
-            322385 | conflicts | *
+            fabric-api | depends | *
+            fabric-language-kotlin | depends | 1.9.0+kotlin.1.8.0
+            know-my-name | recommends | *
+            animatica | suggests | *
+            optifabric | conflicts | *
 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           github-files-secondary: dist/*-@(dev|sources|javadoc).jar

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -58,6 +58,7 @@ jobs:
           # Update manually each time fabric.mod.json is edited until a better solution is found,
           # or Kir-Antipov/mc-publish@v4 is released. Copy values from src/main/resources/fabric.mod.json
           game-versions: |
+            1.19.4
             1.19.3
             1.19.2
             1.19.1

--- a/OptiGUI/build.gradle.kts
+++ b/OptiGUI/build.gradle.kts
@@ -1,13 +1,8 @@
-import org.jetbrains.dokka.gradle.DokkaTask
-import java.time.LocalDateTime
-import java.net.URL as JavaNetUrl
-
 plugins {
     id("fabric-loom")
     kotlin("jvm")
     id("net.kyori.blossom")
     id("maven-publish")
-    id("org.jetbrains.dokka")
 }
 
 base { archivesName.set(project.extra["archives_base_name"] as String) }
@@ -92,38 +87,6 @@ tasks.test {
     }
 }
 
-tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets.configureEach {
-        val dokkaBaseConfiguration = """
-            {
-              "footerMessage": "&copy; 2022-${LocalDateTime.now().year} opekope2"
-            }
-        """
-        pluginsMapConfiguration.set(
-            mapOf(
-                // fully qualified plugin name to json configuration
-                "org.jetbrains.dokka.base.DokkaBase" to dokkaBaseConfiguration
-            )
-        )
-
-        sourceLink {
-            localDirectory.set(projectDir.resolve("src"))
-            remoteUrl.set(JavaNetUrl("https://github.com/opekope2/OptiGUI-Next/tree/main/OptiGUI/src"))
-            remoteLineSuffix.set("#L")
-        }
-        perPackageOption {
-            matchingRegex.set("opekope2\\.optigui\\.internal(.*)")
-            suppress.set(true)
-        }
-    }
-}
-
-val javadocJar by tasks.registering(Jar::class) {
-    dependsOn(tasks.dokkaHtml)
-    from(tasks.dokkaHtml.flatMap { it.outputDirectory })
-    archiveClassifier.set("javadoc")
-}
-
 publishing {
     publications {
         create<MavenPublication>("maven") {
@@ -136,8 +99,6 @@ publishing {
                 artifactId = base.archivesName.get()
                 version = project.version.toString()
             }
-
-            artifact(javadocJar.get())
 
             from(components["java"])
         }

--- a/OptiGUI/src/main/kotlin/opekope2/optifinecompat/properties/ChestBoatProperties.kt
+++ b/OptiGUI/src/main/kotlin/opekope2/optifinecompat/properties/ChestBoatProperties.kt
@@ -1,0 +1,18 @@
+package opekope2.optifinecompat.properties
+
+import net.minecraft.util.Identifier
+
+/**
+ * Chest boat OptiFine container properties.
+ *
+ * @param variant The wood the boat is made of. Possible values:
+ * `acacia`, `bamboo`, `birch`, `cherry`, `dark_oak`, `jungle`, `mangrove`, `oak`, `spruce`
+ */
+data class ChestBoatProperties(
+    override val container: String,
+    override val texture: Identifier,
+    override val name: String?,
+    override val biome: Identifier?,
+    override val height: Int,
+    val variant: String
+) : GeneralProperties(container, texture, name, biome, height)

--- a/OptiGUI/src/main/kotlin/opekope2/optigui/internal/optifinecompat/ChestBoat.kt
+++ b/OptiGUI/src/main/kotlin/opekope2/optigui/internal/optifinecompat/ChestBoat.kt
@@ -1,0 +1,51 @@
+package opekope2.optigui.internal.optifinecompat
+
+import net.minecraft.entity.Entity
+import net.minecraft.entity.vehicle.ChestBoatEntity
+import net.minecraft.util.Nameable
+import opekope2.filter.*
+import opekope2.optifinecompat.properties.ChestBoatProperties
+import opekope2.optigui.resource.Resource
+import opekope2.optigui.service.RegistryLookupService
+import opekope2.optigui.service.getService
+import opekope2.util.TexturePath
+import opekope2.util.splitIgnoreEmpty
+
+private const val CONTAINER = "_chest_boat"
+private val texture = TexturePath.GENERIC_54
+
+fun createChestBoatFilter(resource: Resource): FilterInfo? {
+    if (resource.properties["container"] != CONTAINER) return null
+    val replacement = findReplacementTexture(resource) ?: return null
+
+    val filters = createGeneralFilters(resource, CONTAINER, texture)
+
+    filters.addForProperty(resource, "variants", { it.splitIgnoreEmpty(*delimiters) }) { variants ->
+            PreProcessorFilter.nullGuarded(
+            { (it.data as? ChestBoatProperties)?.variant },
+            FilterResult.Mismatch(),
+            ContainingFilter(variants)
+        )
+    }
+
+    return FilterInfo(
+        PostProcessorFilter(ConjunctionFilter(filters), replacement),
+        setOf(texture)
+    )
+}
+
+internal fun processChestBoat(chestBoat: Entity): Any? {
+    if (chestBoat !is ChestBoatEntity) return null
+    val lookup = getService<RegistryLookupService>()
+
+    val world = chestBoat.world ?: return null
+
+    return ChestBoatProperties(
+        container = CONTAINER,
+        texture = texture,
+        name = (chestBoat as? Nameable)?.customName?.string,
+        biome = lookup.lookupBiome(world, chestBoat.blockPos),
+        height = chestBoat.blockY,
+        variant = chestBoat.variant.getName()
+    )
+}

--- a/OptiGUI/src/main/kotlin/opekope2/optigui/internal/optifinecompat/Initializer.kt
+++ b/OptiGUI/src/main/kotlin/opekope2/optigui/internal/optifinecompat/Initializer.kt
@@ -4,6 +4,7 @@ import net.minecraft.block.entity.*
 import net.minecraft.entity.mob.SkeletonHorseEntity
 import net.minecraft.entity.mob.ZombieHorseEntity
 import net.minecraft.entity.passive.*
+import net.minecraft.entity.vehicle.ChestBoatEntity
 import net.minecraft.entity.vehicle.ChestMinecartEntity
 import net.minecraft.entity.vehicle.HopperMinecartEntity
 import opekope2.optigui.InitializerContext
@@ -36,6 +37,7 @@ internal fun initialize(context: InitializerContext) {
     // Register entity filter factories
     context.registerFilterFactory(::createVillagerFilter)
     context.registerFilterFactory(::createHorseFilter)
+    context.registerFilterFactory(::createChestBoatFilter)
 
     // Register preprocessor for brewing stand
     context.registerPreprocessor<BrewingStandBlockEntity>(::processBrewingStand)
@@ -58,6 +60,9 @@ internal fun initialize(context: InitializerContext) {
     context.registerPreprocessor<EnderChestBlockEntity>(::processChest)
     context.registerPreprocessor<BarrelBlockEntity>(::processChest)
     context.registerPreprocessor<ChestMinecartEntity>(::processChestMinecart)
+
+    // Register preprocessor for chest boats
+    context.registerPreprocessor<ChestBoatEntity>(::processChestBoat)
 
     // Register preprocessor for beacon
     context.registerPreprocessor<BeaconBlockEntity>(::processBeacon)

--- a/OptiGlue/1.19.3/src/main/resources/fabric.mod.json
+++ b/OptiGlue/1.19.3/src/main/resources/fabric.mod.json
@@ -25,7 +25,7 @@
   "depends": {
     "fabric-resource-loader-v0": "*",
     "fabric-language-kotlin": ">=${fabric_language_kotlin}",
-    "minecraft": ">=1.19.3 <1.19.4",
+    "minecraft": ">=1.19.3 <1.19.5",
     "java": ">=${java}"
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx4G
 org.gradle.warning.mode=all
 org.gradle.parallel=true
 ##########################################################################
-loom_version=1.0-SNAPSHOT
+loom_version=1.1-SNAPSHOT
 java_version=17
 ##########################################################################
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx4G
 org.gradle.warning.mode=all
 org.gradle.parallel=true
 ##########################################################################
-loom_version=1.1-SNAPSHOT
+loom_version=1.0-SNAPSHOT
 java_version=17
 ##########################################################################
 # Mod Properties

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loom_version=1.1-SNAPSHOT
 java_version=17
 ##########################################################################
 # Mod Properties
-mod_version=2.0.0-alpha.5
+mod_version=2.0.0-alpha.6
 maven_group=opekope2.optigui
 ##########################################################################
 # Kotlin Dependencies


### PR DESCRIPTION
- Mark Minecraft 1.19.4 as supported
- Add support for chest boats
- Remove javadoc from Jitpack. It will be added to the future GitHub page.

Closes #8 