### PR TITLE
Organized with logical spacing

### DIFF
--- a/OptiGUI/src/main/resources/assets/optigui/lang/en_us.json
+++ b/OptiGUI/src/main/resources/assets/optigui/lang/en_us.json
@@ -2,9 +2,13 @@
   "optigui.enum.InspectorNbtDumpOption.DISABLED": "Disabled",
   "optigui.enum.InspectorNbtDumpOption.VALUES_AND_TYPES": "Values & types",
   "optigui.enum.InspectorNbtDumpOption.VALUES_ONLY": "Values only",
+  
   "optigui.enum.ResourceLoadingErrorFilter.ERRORS_AND_WARNINGS": "Errors & warnings",
   "optigui.enum.ResourceLoadingErrorFilter.ERRORS_ONLY": "Errors only",
   "optigui.enum.ResourceLoadingErrorFilter.NOTHING": "Never",
+
+
+  
   "optigui.gui.rp_converter.conversion_fail": "OptiGUI couldn't convert some resources",
   "optigui.gui.rp_converter.conversion_success": "Resource pack converted successfully",
   "optigui.gui.rp_converter.convert": "Convert resource pack",
@@ -15,13 +19,18 @@
   "optigui.gui.rp_converter.output_file": "Output file name",
   "optigui.gui.rp_converter.target_namespace": "Target namespace",
   "optigui.gui.rp_converter.title": "OptiGUI Resource Pack Converter",
+  
   "optigui.gui.rp_loader.copy_to_clipboard": "Copy to clipboard",
   "optigui.gui.rp_loader.do_not_show_again": "Do not show again",
   "optigui.gui.rp_loader.do_not_show_again.tooltip": "You can change this anytime in OptiGUI settings",
   "optigui.gui.rp_loader.load_fail": "OptiGUI couldn't load some resources",
   "optigui.gui.rp_loader.unknown_pack": "Unknown resource pack",
   "optigui.gui.rp_loader.unknown_resource": "Unknown resource",
+
+
+  
   "optigui.inspector": "OptiGUI Inspector",
+  
   "optigui.inspector.description": "Click to generate a JSON resource",
   "optigui.inspector.description.clicked": "JSON resource copied to clipboard",
   "optigui.inspector.description.debug": "Click to open the filter debugger",
@@ -29,62 +38,97 @@
   "optigui.inspector.description.debug.clicked.error": "Error collecting debug data",
   "optigui.inspector.description.debug.clicked.success": "Filter debugger opened in your browser",
   "optigui.inspector.description.hide": "You can hide this in OptiGUI settings",
+  
   "optigui.inspector.key.more_info": "Hold %s for more information",
+  
   "optigui.inspector.nbt_dumping_disabled": "NBT dumping is disabled in OptiGUI settings",
+  
   "optigui.inspector.title": "OptiGUI (%s)",
   "optigui.inspector.title.alpha": "OptiGUI alpha (%s)",
   "optigui.inspector.title.beta": "OptiGUI beta (%s)",
   "optigui.inspector.title.custom_textures": "custom textures",
   "optigui.inspector.title.original_textures": "original textures",
+
+  
+  
   "optigui.narration.rp_loader.error": "Error in resource %s: %s",
   "optigui.narration.rp_loader.error_list": "Error list",
   "optigui.narration.rp_loader.resource_pack": "Errors in resource pack %s",
   "optigui.narration.rp_loader.warning": "Warning in resource %s: %s",
+
+
+  
   "optigui.rp_loader.info.load_success": "Loaded resource",
   "optigui.rp_loader.info.load_time_filtered": "Skipping resource because of load-time filter",
   "optigui.rp_loader.info.loading_resource": "Loading resource",
+  
   "optigui.rp_loader.warn.missing_sprites": "Missing sprites: %s",
   "optigui.rp_loader.warn.missing_textures": "Missing textures: %s",
+  
   "optigui.rp_loader.warn.newest_supported_json_format": "newest supported format",
+  
   "optigui.rp_loader.warn.no_interaction_target": "No interaction targets (blocks, entities, items, inventory, unknown) were specified",
   "optigui.rp_loader.warn.no_textures_or_sprites": "No valid textures or sprites were specified",
+  
   "optigui.rp_loader.warn.unsupported_json_format": "Unsupported JSON resource format",
+
+
+  
   "optigui.validation.error.duplicate_filters": "Duplicate filters: %s",
+
   "optigui.validation.error.empty_map": "Empty map",
+  
   "optigui.validation.error.no_filter": "No such filter: %s",
   "optigui.validation.error.no_filter_type": "No such filter type: %s",
+  
   "optigui.validation.error.not_a_number": "Not a number: %s",
   "optigui.validation.error.not_a_number_or_string": "Not a number or string: %s",
   "optigui.validation.error.not_a_relative_identifier": "Not a relative resource location: %s",
   "optigui.validation.error.not_an_nbt_transformer": "Not an NBT transformer: %s",
+  
   "optigui.validation.error.of_incompatible_variants": "Incompatible variants: %s",
+  
   "optigui.validation.error.of_invalid_bool": "Invalid boolean: %s",
   "optigui.validation.error.of_invalid_profession": "Invalid villager profession: %s",
   "optigui.validation.error.of_invalid_range": "Invalid range: %s",
+  
   "optigui.validation.error.of_texture_required": "At least one texture or texture.PATH is required",
+  
   "optigui.validation.error.unsupported_filter": "Unsupported filter: %s",
+  
   "optigui.validation.error.wrong_filter_type": "Expected filter type %s, got %s",
+
+
+  
   "text.autoconfig.optigui.category.inspector": "Inspector",
   "text.autoconfig.optigui.category.interaction": "Interaction",
   "text.autoconfig.optigui.category.resourceLoading": "Resource loading",
   "text.autoconfig.optigui.category.utils": "Utilities",
+  
   "text.autoconfig.optigui.option.dumpNbt": "Dump NBT",
   "text.autoconfig.optigui.option.dumpNbt.@Tooltip": "Include NBT data in generated JSON resources",
+  
   "text.autoconfig.optigui.option.enableInspector": "Enable inspector",
   "text.autoconfig.optigui.option.enableInspector.@Tooltip": "Show an inspector button on supported inventory screens",
+  
   "text.autoconfig.optigui.option.errorsAndWarnings": "Resource loading logs",
   "text.autoconfig.optigui.option.errorsAndWarnings.@Tooltip": "Show errors and warnings occurred while loading resources",
   "text.autoconfig.optigui.option.errorsAndWarnings.button": "View",
+  
   "text.autoconfig.optigui.option.interactWithAttackKey": "Interact using the attack key",
   "text.autoconfig.optigui.option.interactWithAttackKey.@Tooltip[0]": "In addition to the use key, attacking also starts an interaction",
   "text.autoconfig.optigui.option.interactWithAttackKey.@Tooltip[1]": "§8Some servers may open a screen menu when attacking an entity",
+  
   "text.autoconfig.optigui.option.keepInteractionFactory": "Remember last interaction",
   "text.autoconfig.optigui.option.keepInteractionFactory.@Tooltip[0]": "Do not end interaction when the screen closes",
   "text.autoconfig.optigui.option.keepInteractionFactory.@Tooltip[1]": "§8Some servers may open other menu screens from a menu screen",
+  
   "text.autoconfig.optigui.option.resourcePackConverter": "Resource Pack Converter",
   "text.autoconfig.optigui.option.resourcePackConverter.@Tooltip": "Convert OptiFine .properties and OptiGUI .ini to OptiGUI JSON resources",
   "text.autoconfig.optigui.option.resourcePackConverter.button": "Open",
+  
   "text.autoconfig.optigui.option.showResourceLoadingErrors": "Show resource loading logs",
   "text.autoconfig.optigui.option.showResourceLoadingErrors.@Tooltip": "Show logs when OptiGUI fails to load a resource",
+  
   "text.autoconfig.optigui.title": "OptiGUI Settings"
 }


### PR DESCRIPTION
Hi! While working on fixing some errors in the German file, I realized how difficult it is to track missing lines in the current dense format.

I decided to reorganize the main file with some logical spacing and grouping because, in my opinion, it makes the whole process much more pleasant and less exhausting for anyone who wants to help with translations. 

I believe this change would save future contributors a lot of time and effort by preventing the kind of mistakes I encountered, but I'd love to hear your thoughts on this.